### PR TITLE
Fixed the bot to use .add_comment on submissions

### DIFF
--- a/ReplyBot/replybot.py
+++ b/ReplyBot/replybot.py
@@ -102,7 +102,10 @@ def replybot():
         sql.commit()
         print('Replying to %s by %s' % (pid, pauthor))
         try:
-            post.reply(REPLYSTRING)
+            if hasattr(post, "reply"):
+                post.reply(REPLYSTRING)
+            else:
+                post.add_comment(REPLYSTRING)
         except praw.errors.Forbidden:
             print('403 FORBIDDEN - is the bot banned from %s?' % post.subreddit.display_name)
 


### PR DESCRIPTION
Posts that are submissions don't have a .reply function, they do have an .add_comment though. The current version of the bot will raise an exception when it detects a keyword in a submission.